### PR TITLE
Quick-and-dirty Python3 and Chainer 4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Oren Melamud, Jacob Goldberger, Ido Dagan. CoNLL, 2016 [[pdf]](http://u.cs.biu.a
 
 ## Requirements
 
-* Python 2.7
-* Chainer 1.7 ([chainer](http://chainer.org/))
+* Python 3.6
+* Chainer 4.2 ([chainer](http://chainer.org/))
 * NLTK 3.0 ([NLTK](http://www.nltk.org/))  - optional (only required for the AWE baseline and MSCC evaluation)
 
 ## Installation

--- a/context2vec/common/context_models.py
+++ b/context2vec/common/context_models.py
@@ -1,5 +1,4 @@
 import math
-from itertools import izip
 
 import numpy as np
 import chainer
@@ -35,15 +34,15 @@ class CbowContext(object):
         bow = self.extract_window(sent_words, position)
         bow_inds = [self.word2index[word] for word in bow if word in self.word2index and word not in self.stopwords ]
         if len(bow_inds) == 0:
-            print "NOTICE: Empty bow context for: " + str(sent_words)
-            print "Trying with stopwords"
+            print("NOTICE: Empty bow context for: " + str(sent_words))
+            print("Trying with stopwords")
             bow_inds = [self.word2index[word] for word in bow if word in self.word2index ]           
         return self.context_rep(bow_inds)
     
     def count2idf(self, word_counts, word2index):
         sum_counts = sum(word_counts.values())
         idf = np.zeros((len(word2index),1), dtype=float)
-        for word, count in word_counts.iteritems():
+        for word, count in word_counts.items():
             if word in word2index:
                 idf[word2index[word],0] = math.log(float(sum_counts)/count)
         return idf
@@ -176,7 +175,7 @@ class BiLstmContext(chainer.Chain):
         
         # concat left-to-right with right-to-left
         sent_bi_h = []
-        for l2r_h, r2l_h in izip(l2r_sent_h, r2l_sent_h):
+        for l2r_h, r2l_h in zip(l2r_sent_h, r2l_sent_h):
             if not self.deep: # projecting hidden state to half out-units dimensionality before concatenating
                 if self.drop_ratio > 0.0:
                     l2r_h = self.lp_l2r(F.dropout(l2r_h, ratio=self.drop_ratio, train=self.train))
@@ -217,7 +216,7 @@ class BiLstmContext(chainer.Chain):
             sent_x.append(x)
             
         accum_loss = None
-        for y,x in izip(sent_y, sent_x):
+        for y,x in zip(sent_y, sent_x):
             loss = self.loss_func(y, x)
             accum_loss = accum_loss + loss if accum_loss is not None else loss 
         

--- a/context2vec/common/context_models.py
+++ b/context2vec/common/context_models.py
@@ -72,8 +72,8 @@ class BiLstmContext(chainer.Chain):
       
     def __init__(self, deep, gpu, word2index, in_units, hidden_units, out_units, loss_func, train, drop_ratio=0.0):
         n_vocab = len(word2index)        
-        l2r_embedding=F.EmbedID(n_vocab, in_units)
-        r2l_embedding=F.EmbedID(n_vocab, in_units)
+        l2r_embedding=L.EmbedID(n_vocab, in_units)
+        r2l_embedding=L.EmbedID(n_vocab, in_units)
         
         if deep:
             super(BiLstmContext, self).__init__(

--- a/context2vec/common/model_reader.py
+++ b/context2vec/common/model_reader.py
@@ -15,9 +15,9 @@ class ModelReader(object):
 
     def __init__(self, config_file):
         self.gpu = -1 # todo support gpu
-        print 'Reading config file: ' + config_file
+        print('Reading config file: ' + config_file)
         params = self.read_config_file(config_file)
-        print 'Config: ', params
+        print('Config: ', params)
         self.w, self.word2index, self.index2word, self.model = self.read_model(params)
         
 

--- a/context2vec/eval/explore_context2vec.py
+++ b/context2vec/eval/explore_context2vec.py
@@ -112,12 +112,12 @@ while True:
     except EOFError:
         break
     except ParseException as e:
-        print "ParseException: {}".format(e)                
+        print("ParseException: {}".format(e))                
     except Exception:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        print "*** print_tb:"
+        print("*** print_tb:")
         traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
-        print "*** print_exception:"
+        print("*** print_exception:")
         traceback.print_exception(exc_type, exc_value, exc_traceback, limit=2, file=sys.stdout)
 
 

--- a/context2vec/eval/mscc_text_tokenize.py
+++ b/context2vec/eval/mscc_text_tokenize.py
@@ -33,7 +33,7 @@ for i, line in enumerate(input_file):
 if len(paragraph_lines) > 0:
     write_paragraph_lines(paragraph_lines)
     
-print 'Read {} lines'.format(i)
+print('Read {} lines'.format(i))
                           
 input_file.close()
 output_file.close()

--- a/context2vec/eval/sentence_completion.py
+++ b/context2vec/eval/sentence_completion.py
@@ -24,7 +24,7 @@ def parse_input(line, word2index):
     
     line = line[line.find(' ')+1:].strip()
     if debug:
-        print line
+        print(line)
     segments = exp.match(line)
     if segments is not None:
         seg_left = segments.group(1)
@@ -35,7 +35,7 @@ def parse_input(line, word2index):
         words_right = word_tokenize(seg_right)
         words = words_left + [target_word] + words_right
         if debug:
-            print words
+            print(words)
         target_pos = len(words_left)
         sent = []
         for word in words:
@@ -44,7 +44,7 @@ def parse_input(line, word2index):
     else:
         raise Exception("Failed to parse line into segments")
     if debug:
-        print sent
+        print(sent)
     return sent, target_pos, target_word
 
 
@@ -71,9 +71,9 @@ def answer_next_question(fd, model, w, word2index):
         sim = target_v.dot(context_v)
         
         if debug:
-            print 'target_word', target_word
-            print 'target_pos', target_pos
-            print 'sim', sim        
+            print('target_word', target_word)
+            print('target_pos', target_pos)
+            print('sim', sim)
         
         if best_sim is None or sim > best_sim:
             best_sim = sim
@@ -87,8 +87,8 @@ def read_next_answer(fd, word2index):
         return None
     _, _, target_word = parse_input(line, word2index)
     if debug:
-        print '\ngold target word', target_word
-        print '***************************'
+        print('\ngold target word', target_word)
+        print('***************************')
     return target_word
 
 
@@ -119,7 +119,7 @@ if __name__ == '__main__':
             correct += 1
             
     accuracy = float(correct) / total_questions
-    print "Accuracy: {0}. Correct: {1}. Total: {2}".format(accuracy, correct, total_questions)
+    print("Accuracy: {0}. Correct: {1}. Total: {2}".format(accuracy, correct, total_questions))
     results_fd.write("Accuracy: {0}. Correct: {1}. Total: {2}.\n".format(accuracy, correct, total_questions))
         
     questions_fd.close()

--- a/context2vec/eval/wsd/dataset_reader.py
+++ b/context2vec/eval/wsd/dataset_reader.py
@@ -155,12 +155,12 @@ if __name__ == '__main__':
     reader = DatasetReader(model)
     dataset, key2ind = reader.read_dataset(sys.argv[1], sys.argv[1]+'.key', train=True)
     
-    print key2ind
+    print(key2ind)
     for oneset in dataset:
-        print
-        print oneset.context_m
-        print oneset.contexts_str
-        print oneset.contexts_v
-        print oneset.instance_ids
-        print oneset.sense_ids
+        print()
+        print(oneset.context_m)
+        print(oneset.contexts_str)
+        print(oneset.contexts_v)
+        print(oneset.instance_ids)
+        print(oneset.sense_ids)
         

--- a/context2vec/eval/wsd/knn.py
+++ b/context2vec/eval/wsd/knn.py
@@ -27,7 +27,7 @@ class Knn(object):
             sense_ids = key_data.sense_ids[ind]
             weight = 1./len(sense_ids)
             if debug:
-                print 'RET: ', similarity[ind], text.strip(), sense_ids
+                print('RET: ', similarity[ind], text.strip(), sense_ids)
             for sid in sense_ids:
                 if sid not in result:
                     result[sid] = weight

--- a/context2vec/eval/wsd/wsd_main.py
+++ b/context2vec/eval/wsd/wsd_main.py
@@ -4,7 +4,6 @@ Evaluates context2vec on the senseval-3 supervised word sense disambiguation ben
 
 import sys
 import numpy as np
-from itertools import izip
 
 
 from knn import Knn
@@ -22,7 +21,7 @@ class DummyContextModel(object):
 if __name__ == '__main__':
     
     if len(sys.argv) < 6:
-        print >> sys.stderr, "Usage: %s <train-filename> <test-filename> <result-filename> <model-params> <k> [paragraph]"  % (sys.argv[0])
+        print("Usage: %s <train-filename> <test-filename> <result-filename> <model-params> <k> [paragraph]"  % (sys.argv[0]), file=sys.stderr)
         sys.exit(1)
         
     train_filename = sys.argv[1]
@@ -33,13 +32,13 @@ if __name__ == '__main__':
     
     if len(sys.argv) > 6:
         isolate_target_sentence = False
-        print "Paragraph contexts"
+        print("Paragraph contexts")
     else:
         isolate_target_sentence = True
-        print "Sentence contexts"    
+        print("Sentence contexts")    
     
     if train_filename == test_filename:
-        print 'Dev run.'
+        print('Dev run.')
         ignore_closest = True
     else:
         ignore_closest = False
@@ -47,7 +46,7 @@ if __name__ == '__main__':
     debug = False
     dummy = False
     
-    print 'Reading model..'
+    print('Reading model..')
     if not dummy:
         model_reader = ModelReader(model_params_filename)
         model = model_reader.model
@@ -55,35 +54,35 @@ if __name__ == '__main__':
         model = DummyContextModel()
     dataset_reader = DatasetReader(model)
     
-    print 'Reading train dataset..'
+    print('Reading train dataset..')
     train_set, train_key2ind, train_ind2key = dataset_reader.read_dataset(train_filename, train_filename+'.key', True, isolate_target_sentence)
     knn = Knn(k, train_set, train_key2ind)
     
-    print 'Reading test dataset..'
+    print('Reading test dataset..')
     test_set, test_key2ind, test_ind2key = dataset_reader.read_dataset(test_filename, test_filename+'.key', False, isolate_target_sentence)
     
-    print 'Starting to classify test set:'
+    print('Starting to classify test set:')
     with open(result_filename, 'w') as o:
         for ind, key_set in enumerate(test_set):
             key = test_ind2key[ind]
             if debug:
-                print 'KEY:', key
-                print
-            for instance_id, vec, text in izip(key_set.instance_ids, key_set.context_m, key_set.contexts_str):
+                print('KEY:', key)
+                print()
+            for instance_id, vec, text in zip(key_set.instance_ids, key_set.context_m, key_set.contexts_str):
                 if debug:
-                    print 'QUERY:', text.strip()
+                    print('QUERY:', text.strip())
                 result = knn.classify(key, vec, ignore_closest, debug)
                 if debug:
-                    print
+                    print()
                 #brother.n 00006 501566/0.5 501573/0.4 503751/0.1
                 result_line = key + ' ' + instance_id
-                for sid, weight in result.iteritems():
+                for sid, weight in result.items():
                     result_line += ' {}/{:.4f}'.format(sid, weight)
                     
                 o.write(result_line+'\n')
                 if debug:
-                    print 'LABELS FOUND: ', result_line
-                    print
+                    print('LABELS FOUND: ', result_line)
+                    print()
             
         
     

--- a/context2vec/train/corpus_by_sent_length.py
+++ b/context2vec/train/corpus_by_sent_length.py
@@ -18,7 +18,7 @@ def get_file(sub_files, corpus_dir, num_filename):
 if __name__ == '__main__':
     
     if len(sys.argv) < 2:
-        print "usage: %s <corpus-file> [max-sent-len]"  % (sys.argv[0])
+        print("usage: %s <corpus-file> [max-sent-len]"  % (sys.argv[0]))
         sys.exit(1)
         
     corpus_file = open(sys.argv[1], 'r')
@@ -26,7 +26,7 @@ if __name__ == '__main__':
         max_sent_len = int(sys.argv[2])
     else:
         max_sent_len = 128    
-    print 'Using maximum sentence length: ' + str(max_sent_len)
+    print('Using maximum sentence length: ' + str(max_sent_len))
     
     corpus_dir = sys.argv[1]+'.DIR'
     os.makedirs(corpus_dir)
@@ -49,7 +49,7 @@ if __name__ == '__main__':
             for word in words:
                 word_counts[word] += 1
                
-    for sub_file in sub_files.itervalues():
+    for sub_file in sub_files.values():
         sub_file.close()
         
     for num_filename, count in sent_counts.most_common():
@@ -58,12 +58,12 @@ if __name__ == '__main__':
     for word, count in word_counts.most_common():
         word_counts_file.write(word+'\t'+str(count)+'\n')
     
-    totals_file.write('total sents read: {}\n'.format(sum(sent_counts.itervalues())))
-    totals_file.write('total words read: {}\n'.format(sum(word_counts.itervalues())))
+    totals_file.write('total sents read: {}\n'.format(sum(sent_counts.values())))
+    totals_file.write('total words read: {}\n'.format(sum(word_counts.values())))
     
     corpus_file.close()
     sent_counts_file.close()
     word_counts_file.close()
     totals_file.close()
     
-    print 'Done'
+    print('Done')

--- a/context2vec/train/sentence_reader.py
+++ b/context2vec/train/sentence_reader.py
@@ -42,7 +42,7 @@ class SentenceReaderDir(object):
         self.path = path
         self.batchsize = batchsize
         self.trimmed_word2count, self.word2index, self.index2word = self.read_and_trim_vocab(trimfreq)
-        self.total_words = sum(self.trimmed_word2count.itervalues())
+        self.total_words = sum(self.trimmed_word2count.values())
         self.fds = []
         
     def open(self):
@@ -74,7 +74,7 @@ class SentenceReaderDir(object):
         index2word = {Toks.UNK:'<UNK>', Toks.BOS:'<BOS>', Toks.EOS:'<EOS>'}
         word2index = {'<UNK>':Toks.UNK, '<BOS>':Toks.BOS, '<EOS>':Toks.EOS}
         unknown_counts = 0
-        for word, count in word2count.iteritems():
+        for word, count in word2count.items():
             if count >= trimfreq and word.lower() != '<unk>' and word.lower() != '<rw>':    
                 ind = len(word2index)
                 word2index[word] = ind
@@ -101,17 +101,17 @@ if __name__ == '__main__':
     reader = SentenceReaderDir(sys.argv[1],int(sys.argv[2]),int(sys.argv[3]))
     
     for i in range(2):
-        print 'epoc', i
+        print('epoc', i)
         reader.open()
         i = 0
         j = 0
         for batch in reader.next_batch():
             if i < 3:
-                print batch
-                print
+                print(batch)
+                print()
             i += 1
             j += len(batch)
-        print 'batches', i
-        print 'sents', j
+        print('batches', i)
+        print('sents', j)
         reader.close()
                      

--- a/context2vec/train/train_context2vec.py
+++ b/context2vec/train/train_context2vec.py
@@ -155,7 +155,7 @@ for epoch in range(args.epoch):
             last_accum_loss = float(accum_loss)
             last_word_count = word_count
 
-    print 'accum words per epoch', word_count, 'accum_loss', accum_loss, 'accum_loss/word', accum_mean_loss
+    print('accum words per epoch', word_count, 'accum_loss', accum_loss, 'accum_loss/word', accum_mean_loss)
     reader.close()
     
 if args.wordsfile != None:        


### PR DESCRIPTION
I have made some very minor changes to the codebase that make it compatible with Python 3 and a newer version of Chainer. We did this because of some truly apocalyptic dependency issues that we were running into when trying to train our own models. Specifically, it appears as though newer Nvidia GPUs have some API-level compatibility issues with the older version of Cuda that is needed for the older version of Cupy that is needed for Chainer 1.7.

Note that I didn't update the code to use a more modern style of Chainer programming, so it is quite likely that there are things that could be made more efficient or idiomatic. I just got it working. :-)