### PR TITLE
Mitigate exploding gradients 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ NOTE:
 * The current code lowercases all corpus words
 * Use of a gpu and mini-batching is highly recommended to achieve good training speeds
 
+### Avoiding exploding gradients
+
+Some users have noted that this configuration can cause exploding gradients
+[(see issue #6)](https://github.com/orenmel/context2vec/issues/6). One option
+is to turn down the learning rate, by reducing the Adam optimizer's alpha from
+0.001 to something lower, e.g. by specifying `-a 0.0005`. As an extra safety
+measure, you can enable gradient clipping which could be set to 5 by using the
+very scientific method of using the value everyone else seems to be using `-gc
+5`.
 
 ## Evaluation
 

--- a/context2vec/train/train_context2vec.py
+++ b/context2vec/train/train_context2vec.py
@@ -67,6 +67,8 @@ def parse_arguments():
     parser.add_argument('--deep', '-d', choices=['yes', 'no'],
                         default=None,
                         help='use deep NN architecture')
+    parser.add_argument('--alpha', '-a', default=0.001, type=float,
+                        help='alpha param for Adam, controls the learning rate')
     
     args = parser.parse_args()
     
@@ -86,6 +88,7 @@ def parse_arguments():
     print('Dropout: {}'.format(args.dropout))
     print('Trimfreq: {}'.format(args.trimfreq))
     print('NS Power: {}'.format(args.ns_power))
+    print('Alpha: {}'.format(args.alpha))
     print('')
        
     return args 
@@ -115,7 +118,7 @@ if args.context == 'lstm':
 else:
     raise Exception('Unknown context type: {}'.format(args.context))
 
-optimizer = O.Adam()
+optimizer = O.Adam(alpha=args.alpha)
 optimizer.setup(model)
 
 STATUS_INTERVAL = 1000000

--- a/context2vec/train/train_context2vec.py
+++ b/context2vec/train/train_context2vec.py
@@ -12,6 +12,7 @@ import chainer.links as L
 import chainer.optimizers as O
 import chainer.serializers as S
 import chainer.computational_graph as C
+from chainer.optimizer_hooks import GradientClipping
 
 from sentence_reader import SentenceReaderDir
 from context2vec.common.context_models import BiLstmContext
@@ -69,6 +70,8 @@ def parse_arguments():
                         help='use deep NN architecture')
     parser.add_argument('--alpha', '-a', default=0.001, type=float,
                         help='alpha param for Adam, controls the learning rate')
+    parser.add_argument('--grad-clip', '-gc', default=None, type=float,
+                        help='if specified, clip l2 of the gradient to this value')
     
     args = parser.parse_args()
     
@@ -89,6 +92,7 @@ def parse_arguments():
     print('Trimfreq: {}'.format(args.trimfreq))
     print('NS Power: {}'.format(args.ns_power))
     print('Alpha: {}'.format(args.alpha))
+    print('Grad clip: {}'.format(args.grad_clip))
     print('')
        
     return args 
@@ -120,6 +124,9 @@ else:
 
 optimizer = O.Adam(alpha=args.alpha)
 optimizer.setup(model)
+
+if args.grad_clip:
+    optimizer.add_hook(GradientClipping(args.grad_clip))
 
 STATUS_INTERVAL = 1000000
 


### PR DESCRIPTION
Further to https://github.com/orenmel/context2vec/issues/6 -- it seems there should be a command line option to turn down the learning rate/alpha. As an extra safety measure we can use optional gradient clipping. I also added a documenting note to the README.